### PR TITLE
Enhanced CMake install features

### DIFF
--- a/regxmllib/CMakeLists.txt
+++ b/regxmllib/CMakeLists.txt
@@ -1,5 +1,6 @@
-cmake_minimum_required (VERSION 3.5)
+cmake_minimum_required (VERSION 3.6)
 project (regxmllibc)
+option(BUILD_SHARED_LIBS Bool OFF)
 
 include(FindXercesC)
 find_package(XercesC REQUIRED)
@@ -7,22 +8,74 @@ include_directories( ${XercesC_INCLUDE_DIR}
 						src/main/cpp
 					)
 
+# Append "_d" if debug lib.
+set(CMAKE_DEBUG_POSTFIX _d) 
 
-file(GLOB_RECURSE SRC_FILES src/main/cpp/*.cpp src/main/cpp/*.h )
-add_library(${PROJECT_NAME} ${SRC_FILES})
+file(GLOB_RECURSE SRC_FILES src/main/cpp/*.cpp )
+file(GLOB_RECURSE INC_FILES src/main/cpp/*.h )
+add_library(${PROJECT_NAME} ${SRC_FILES} ${INC_FILES})
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 98)
 
 
 
 target_link_libraries ( ${PROJECT_NAME} ${XercesC_LIBRARY} )
 
-foreach(source IN LISTS SRC_FILES)
+foreach(source IN LISTS SRC_FILES INC_FILES)
 	file(RELATIVE_PATH rel_source ${CMAKE_CURRENT_SOURCE_DIR}/src/main/cpp/com/ ${source})
     get_filename_component(source_path ${rel_source} DIRECTORY)
     string(REPLACE "\\" "/" source_path_msvc "${source_path}")
     source_group("${source_path_msvc}" FILES "${source}")
 endforeach()
 
+if(WIN32 AND NOT CYGWIN)
+  set(DEF_INSTALL_CMAKE_DIR CMake)
+else()
+  set(DEF_INSTALL_CMAKE_DIR lib/CMake/${PROJECT_NAME})
+endif()
+set(INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR} CACHE PATH
+  "Installation directory for CMake files")
+set(INSTALL_LIB_DIR lib CACHE PATH "Installation directory for libraries")
+set(INSTALL_INCLUDE_DIR include CACHE PATH "Installation directory for header files")
+
+# Make relative paths absolute (needed later on)
+foreach(p LIB BIN INCLUDE CMAKE)
+  set(var INSTALL_${p}_DIR)
+  if(NOT IS_ABSOLUTE "${${var}}")
+    set(${var} "${CMAKE_INSTALL_PREFIX}/${${var}}")
+  endif()
+endforeach()
+
+
+# Export the package for use from the build-tree
+# (this registers the build-tree with a global CMake-registry)
+export(PACKAGE ${PROJECT_NAME})
+ 
+# Create the ${PROJECT_NAME}Config.cmake file in the install tree
+file(RELATIVE_PATH REL_INCLUDE_DIR "${INSTALL_CMAKE_DIR}" "${INSTALL_INCLUDE_DIR}")
+set(CONF_INCLUDE_DIRS "\${REGXMLLIBC_CMAKE_DIR}/${REL_INCLUDE_DIR}")
+configure_file(${PROJECT_NAME}Config.cmake.in
+  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${PROJECT_NAME}Config.cmake" @ONLY)
+
+
+install(EXPORT ${PROJECT_NAME}Targets DESTINATION
+  ${INSTALL_CMAKE_DIR} COMPONENT dev)
+
+install(TARGETS ${PROJECT_NAME} 
+EXPORT ${PROJECT_NAME}Targets DESTINATION ${INSTALL_LIB_DIR}
+)
+
+foreach ( file ${INC_FILES} )
+    get_filename_component( dir ${file} DIRECTORY )
+    file(RELATIVE_PATH dir2 "${CMAKE_CURRENT_SOURCE_DIR}/src/main/cpp" ${dir})
+    message(STATUS ${dir})
+    message(STATUS ${dir2})
+    install( FILES ${file} DESTINATION "${INSTALL_INCLUDE_DIR}/${PROJECT_NAME}/${dir2}" )
+endforeach()
+
+
+install(FILES
+  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${PROJECT_NAME}Config.cmake"
+  DESTINATION "${INSTALL_CMAKE_DIR}" COMPONENT dev)
 
 
 #unit tests

--- a/regxmllib/regxmllibcConfig.cmake.in
+++ b/regxmllib/regxmllibcConfig.cmake.in
@@ -1,0 +1,21 @@
+#  REGXMLLIBC_INCLUDE_DIRS - include directories for regxmllibc
+#  REGXMLLIBC_LIBRARIES    - libraries to link against
+#  REGXMLLIBC_EXECUTABLE   - the bar executable
+ 
+# Compute paths
+get_filename_component(REGXMLLIBC_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+# set(regxmllibc_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@/regxmllibc")
+set(REGXMLLIBC_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@/regxmllibc")
+ 
+# Our library dependencies (contains definitions for IMPORTED targets)
+if(NOT TARGET regxmllibc AND NOT regxmllibc_BINARY_DIR)
+  include("${REGXMLLIBC_CMAKE_DIR}/regxmllibcTargets.cmake")
+endif()
+ 
+# These are IMPORTED targets created by FooBarTargets.cmake
+set(REGXMLLIBC_LIBRARIES
+        "$<$<NOT:$<CONFIG:Debug>>:${PROJECT_NAME}>"
+        "$<$<CONFIG:Debug>:${PROJECT_NAME}${CMAKE_DEBUG_POSTFIX}>"
+)
+
+


### PR DESCRIPTION
Features:
- Different targets for Release and Debug (the latter with appendix "_d"
- Creates regxmllibcConfig.cmake and regxmllibcTargets.cmake files that allow other applications to discover regxmllib using find_package(regxmllibc)
- GUI Option for BUILD_SHARED (default: off)
- Installs entire *.h tree
- Standard install targets for MacOS and Windows (Linux untested)
- Tested with MacOS 10.10 and Win 7 / VS 2015 