### PR TITLE
Use readFully() to prevent erroneous EOFException

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,5 @@ matrix:
         - sudo make install
       
     - language: java
+      jdk:
+        - openjdk8

--- a/src/main/java/com/sandflow/smpte/klv/KLVInputStream.java
+++ b/src/main/java/com/sandflow/smpte/klv/KLVInputStream.java
@@ -106,11 +106,9 @@ public class KLVInputStream extends InputStream implements DataInput {
      */
     public AUID readAUID() throws IOException, EOFException {
         byte[] auid = new byte[16];
-        
-        if (read(auid) < auid.length) {
-            throw new EOFException();
-        }
-        
+
+        readFully(auid);
+
         return new AUID(auid);
     }
 
@@ -144,9 +142,7 @@ public class KLVInputStream extends InputStream implements DataInput {
 
         byte[] octets = new byte[bersz];
 
-        if (read(octets) < bersz) {
-            throw new EOFException();
-        }
+        readFully(octets);
 
         for (int i = 0; i < bersz; i++) {
             int tmp = (((int) octets[i]) & 0xFF);
@@ -179,9 +175,7 @@ public class KLVInputStream extends InputStream implements DataInput {
 
         byte[] value = new byte[(int) len];
 
-        if (len != read(value)) {
-            throw new EOFException("EOF reached while reading Value.");
-        }
+        readFully(value);
 
         return new MemoryTriplet(auid, value);
     }

--- a/src/main/java/com/sandflow/smpte/mxf/MXFInputStream.java
+++ b/src/main/java/com/sandflow/smpte/mxf/MXFInputStream.java
@@ -71,10 +71,8 @@ public class MXFInputStream extends KLVInputStream {
     public UUID readUUID() throws IOException, EOFException {
         byte[] uuid = new byte[16];
 
-        if (read(uuid) < uuid.length) {
-            throw new EOFException();
-        }
-        
+        readFully(uuid);
+
         if (getByteOrder() == ByteOrder.LITTLE_ENDIAN) {
 
            uuidLEtoBE(uuid);
@@ -92,11 +90,9 @@ public class MXFInputStream extends KLVInputStream {
      */
     public IDAU readIDAU() throws IOException, EOFException {
         byte[] idau = new byte[16];
-        
-        if (read(idau) < idau.length) {
-            throw new EOFException();
-        }
-        
+
+        readFully(idau);
+
         if (getByteOrder() == ByteOrder.LITTLE_ENDIAN) {
 
            uuidLEtoBE(idau);
@@ -115,9 +111,7 @@ public class MXFInputStream extends KLVInputStream {
     public UMID readUMID() throws IOException, EOFException {
         byte[] umid = new byte[32];
 
-        if (read(umid) < umid.length) {
-            throw new EOFException();
-        }
+        readFully(umid);
 
         return new UMID(umid);
     }

--- a/src/main/java/com/sandflow/smpte/regxml/FragmentBuilder.java
+++ b/src/main/java/com/sandflow/smpte/regxml/FragmentBuilder.java
@@ -71,6 +71,7 @@ import java.math.BigInteger;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -999,6 +1000,10 @@ public class FragmentBuilder {
                 br += count;
             }
 
+            if (br < len) {
+                val = Arrays.copyOf(val, br);
+            }
+
             String str = null;
 
             if (br == 0) {
@@ -1269,6 +1274,10 @@ public class FragmentBuilder {
                 int count = value.read(val, br, len - br);
                 if (count < 0) break;
                 br += count;
+            }
+
+            if (br < len) {
+                val = Arrays.copyOf(val, br);
             }
 
             if (br == 0) {

--- a/src/main/java/com/sandflow/smpte/regxml/FragmentBuilder.java
+++ b/src/main/java/com/sandflow/smpte/regxml/FragmentBuilder.java
@@ -991,7 +991,13 @@ public class FragmentBuilder {
 
             byte[] val = new byte[len];
 
-            int br = value.read(val);
+            int br = 0;
+
+            while (br < len) {
+                int count = value.read(val, br, len - br);
+                if (count < 0) break;
+                br += count;
+            }
 
             String str = null;
 
@@ -1257,7 +1263,13 @@ public class FragmentBuilder {
 
             byte[] val = new byte[len];
 
-            int br = value.read(val);
+            int br = 0;
+
+            while (br < len) {
+                int count = value.read(val, br, len - br);
+                if (count < 0) break;
+                br += count;
+            }
 
             if (br == 0) {
 

--- a/src/main/java/com/sandflow/smpte/regxml/FragmentBuilder.java
+++ b/src/main/java/com/sandflow/smpte/regxml/FragmentBuilder.java
@@ -938,6 +938,24 @@ public class FragmentBuilder {
 
     }
 
+    private byte[] fullyReadBytes(MXFInputStream value, int len) throws IOException {
+        byte[] bytes = new byte[len];
+
+        int br = 0;
+
+        while (br < len) {
+            int count = value.read(bytes, br, len - br);
+            if (count < 0) break;
+            br += count;
+        }
+
+        if (br < len) {
+            bytes = Arrays.copyOf(bytes, br);
+        }
+
+        return bytes;
+    }
+
     void applyRule5_2(Element element, MXFInputStream value, EnumerationTypeDefinition definition) throws RuleException, IOException {
 
         try {
@@ -990,23 +1008,11 @@ public class FragmentBuilder {
                 }
             }
 
-            byte[] val = new byte[len];
-
-            int br = 0;
-
-            while (br < len) {
-                int count = value.read(val, br, len - br);
-                if (count < 0) break;
-                br += count;
-            }
-
-            if (br < len) {
-                val = Arrays.copyOf(val, br);
-            }
+            byte[] val = fullyReadBytes(value, len);
 
             String str = null;
 
-            if (br == 0) {
+            if (val.length == 0) {
 
                 str = "ERROR";
 
@@ -1070,14 +1076,14 @@ public class FragmentBuilder {
 
                     addInformativeComment(element, evt.getReason());
 
-                } else if (br != len) {
+                } else if (val.length != len) {
 
                     FragmentEvent evt = new FragmentEvent(
                             EventCodes.VALUE_LENGTH_MISMATCH,
                             String.format(
                                     "Incorrect length: expected %d and received %d",
                                     len,
-                                    br
+                                    val.length
                             ),
                             String.format(
                                     "Enumeration %s at Element %s",
@@ -1266,21 +1272,9 @@ public class FragmentBuilder {
                     break;
             }
 
-            byte[] val = new byte[len];
+            byte[] val = fullyReadBytes(value, len);
 
-            int br = 0;
-
-            while (br < len) {
-                int count = value.read(val, br, len - br);
-                if (count < 0) break;
-                br += count;
-            }
-
-            if (br < len) {
-                val = Arrays.copyOf(val, br);
-            }
-
-            if (br == 0) {
+            if (val.length == 0) {
 
                 element.setTextContent("NaN");
 
@@ -1306,14 +1300,14 @@ public class FragmentBuilder {
 
                     element.setTextContent(bi.toString());
 
-                    if (br != len) {
+                    if (val.length != len) {
 
                         FragmentEvent evt = new FragmentEvent(
                                 EventCodes.VALUE_LENGTH_MISMATCH,
                                 String.format(
                                         "Incorrect field length: expected %d and parsed %d.",
                                         len,
-                                        br
+                                        val.length
                                 ),
                                 String.format(
                                         "Integer %s at Element %s",


### PR DESCRIPTION
`InputStream.read(byte[])` only blocks until at least one byte is read. This means it can return having read less than the length of the array, which can result in an `EOFException` being thrown  even though the end of the stream has not been reached.

I noticed this issue when calling `MXFFragmentBuilder.fromInputStream` with different types of `InputStream`. Reading an MXF file with `FileInputStream` worked ok, but the same MXF file being read from an S3 bucket would result in an `EOFException`.

I have replaced `InputStream.read(byte[])` with either `DataInputStream.readFully(byte[])` (which throws `EOFException` if it can't fully read the array) or added a loop to read until the array is full. I'm not that familiar with code and there maybe other places I have not updated, but these changes were sufficient to prevent `EOFException` for my usage.